### PR TITLE
bugfix to mipArea(), removing ragged area plots

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.git$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mip
 Type: Package
 Title: Comparison of multi-model runs
-Version: 0.122.0
-Date: 2019-08-24
+Version: 0.122.1
+Date: 2019-08-28
 Authors@R: c(person("David", "Klein", email = "dklein@pik-potsdam.de", role = c("aut","cre")),
              person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut")),
              person("Lavinia", "Baumstark", email = "baumstark@pik-potsdam.de", role = "aut"),
@@ -30,4 +30,4 @@ RoxygenNote: 6.1.1
 Encoding: UTF-8
 LazyData: yes
 Suggests: testthat
-ValidationKey: 22121040
+ValidationKey: 22144056

--- a/R/mipArea.R
+++ b/R/mipArea.R
@@ -139,18 +139,13 @@ mipArea <- function(x, stack_priority=c("variable", "region"), total=TRUE, scale
   # separate positive and negative parts of data for area plot
   tmp <- droplevels(x[x$scenario!="historical",])
   
-  pos <- tmp
-  pos$value[pos$value < 0] <- 0
-  neg <- tmp
-  neg$value[neg$value > 0] <- 0
+  pos <- tmp[tmp$value < 0,]
+  neg <- tmp[tmp$value > 0,]
   
   if (!is.null(hist)) {
     tmp <- droplevels(x[x$scenario=="historical",])
-    postmp <- tmp
-    postmp$value[postmp$value < 0] <- 0
-    
-    negtmp <- tmp
-    negtmp$value[negtmp$value > 0] <- 0
+    postmp <- tmp$value[tmp$value < 0]
+    negtmp <- tmp$value[tmp$value > 0]
   
     pos_h <- NULL
     neg_h <- NULL


### PR DESCRIPTION
Used to look like this
![buggy_mipArea](https://user-images.githubusercontent.com/53254462/63841241-bfa98480-c982-11e9-9460-16e86b281689.png)

now looks like this
![fixed_mipArea](https://user-images.githubusercontent.com/53254462/63841255-c3d5a200-c982-11e9-8366-8996be5c3560.png)

NB: After a sign-change, there is a step in the in the area plot (see blue area in 2035 above).  This might introduce ugly "holes", when it happens to a time series within the plot (one that has others above/below it).
This can't be helped.  R/ggplot2 handles area plots differently than Matlab does.  Working around this would necessitate to compute the cross-over point for all time series and adding a zero data-point for both (positive and negative) sub-series at that point.  Not even sure this would work.  It certainly wouldn't for time series crossing abscissa more than once (not sure if we have data like that).

A possible alternative would be to use `geom_col()` together with `quitte::add_remind_timesteps_columns()`.
![geom_col](https://user-images.githubusercontent.com/53254462/63842854-b40b8d00-c985-11e9-82b5-d4bd4cca9b2f.png)
