### PR TITLE
add option to search for plot styles by regular expression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mip
 Type: Package
 Title: Comparison of multi-model runs
-Version: 0.123.2
+Version: 0.124.0
 Date: 2019-11-08
 Authors@R: c(person("David", "Klein", email = "dklein@pik-potsdam.de", role = c("aut","cre")),
              person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut")),
@@ -31,4 +31,4 @@ RoxygenNote: 6.1.1
 Encoding: UTF-8
 LazyData: yes
 Suggests: testthat
-ValidationKey: 22432256
+ValidationKey: 22577920


### PR DESCRIPTION
Makes `plotstyle()` a little searchable if one is unsure what's there and what isn't.
```
> plotstyle('^Final Energy\\|.*Biomass', regexp = TRUE)
                Final Energy|Solids|Biomass Final Energy|Transportation|Liquids|Biomass 
                                  "#00b219"                                   "#00b219" 
```
```
> plotstyle('^[A-Z]{3}$', regexp = TRUE, out = 'all')
                               legend   color marker linestyle
AFR                            Africa #00BAFF     NA          
CPA            Centrally planned Asia #F24200     NA          
EUR                            Europe #00E539     NA          
FSU States of the former Sovjet Union #D900BC     NA          
LAM                     Latin America #FFA500     NA          
MEA          Middle East/North Africa #000FA6     NA          
NAM                     North America #8C5400     NA          
PAO                      Pacific OECD #007362     NA          
PAS                      Pacific Asia #730002     NA          
SAS                        South Asia #175900     NA          
GLO                             World #261E00     NA          
ROW                     Rest of World #007362     NA          
JPN                             Japan #B5BF00     NA          
CHN                             China #F24200     NA          
IND                             India #175900     NA          
OAS                        other Asia #730002     NA          
RUS                            Russia #D900BC     NA          
USA                               USA #8C5400     NA          
CDR                               CDR #5d206c     NA          
IEA                               IEA #000000      3          
```
Implements issue #5