### PR TITLE
Add markers multi line plot

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '25721550'
+ValidationKey: '25913440'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mip: Comparison of multi-model runs",
-  "version": "0.135.0",
+  "version": "0.136.0",
   "description": "<p>Package contains generic functions to produce comparison plots of multi-model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mip
 Type: Package
 Title: Comparison of multi-model runs
-Version: 0.135.0
-Date: 2022-03-02
+Version: 0.136.0
+Date: 2022-03-03
 Authors@R: c(person("David", "Klein", email = "dklein@pik-potsdam.de", role = c("aut","cre")),
              person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut")),
              person("Lavinia", "Baumstark", email = "baumstark@pik-potsdam.de", role = "aut"),

--- a/R/showLinePlotsWithTarget.R
+++ b/R/showLinePlotsWithTarget.R
@@ -28,10 +28,9 @@ showLinePlotsWithTarget <- function(
   stopifnot(is.character(vars))
   stopifnot(is.character(scales) && length(scales) == 1)
 
-  targetPattern <- vars %>%
-    paste0("|target|") %>%
-    gsub("\\|", "\\\\|", .) %>%
-    paste0(collapse = "|")
+  targetPattern <- paste0(vars, "|target|")
+  targetPattern <- gsub("\\|", "\\\\|", targetPattern)
+  targetPattern <- paste0(targetPattern, collapse = "|")
   dTar <- data %>%
     filter(grepl(.env$targetPattern, .data$variable)) %>%
     droplevels()

--- a/R/showMultiLinePlotsByVariable.R
+++ b/R/showMultiLinePlotsByVariable.R
@@ -110,25 +110,25 @@ showMultiLinePlotsByVariable <- function(
     expand_limits(y = 0) +
     ylab(label) + xlab(xLabel)
   if (showHistorical) {
-    p1 <- p1 + 
+    p1 <- p1 +
       geom_point(data = dMainHist, aes(shape = .data$model)) +
       geom_line(data = dMainHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5)
     p2 <- p2 +
       geom_point(data = dRegiHist, aes(shape = .data$model)) +
       geom_line(data = dRegiHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5)
-  } 
+  }
   # Add markers for certain years.
   if (length(yearsByVariable) > 0) {
     p1 <- p1 +
       geom_point(
-      data = dMainScen %>% 
-        filter(.data$period %in% .env$yearsByVariable) %>% 
+      data = dMainScen %>%
+        filter(.data$period %in% .env$yearsByVariable) %>%
         mutate(year = factor(.data$period)),
       mapping = aes(.data$value.x, .data$value, shape = .data$year))
     p2 <- p2 +
       geom_point(
-        data = dRegiScen %>% 
-          filter(.data$period %in% .env$yearsByVariable) %>% 
+        data = dRegiScen %>%
+          filter(.data$period %in% .env$yearsByVariable) %>%
           mutate(year = factor(.data$period)),
         mapping = aes(.data$value.x, .data$value, shape = .data$year))
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.135.0**
+R package **mip**, version **0.136.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P (2022). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.135.0, <URL: https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P (2022). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.136.0, <URL: https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.135.0},
+  note = {R package version 0.136.0},
   doi = {10.5281/zenodo.1158586},
   url = {https://github.com/pik-piam/mip},
 }

--- a/man/showMultiLinePlotsByVariable.Rd
+++ b/man/showMultiLinePlotsByVariable.Rd
@@ -12,7 +12,7 @@ showMultiLinePlotsByVariable(
   showHistorical = FALSE,
   mainReg = getOption("mip.mainReg"),
   histRefModel = getOption("mip.histRefModel"),
-  yearsByVariable = getOption("mip.yearsByVariable")
+  yearsByVariable = getOption("mip.yearsBarPlot")
 )
 }
 \arguments{
@@ -37,7 +37,7 @@ be chosen for historical data. Use \code{options(mip.histRefModel=<value>)}
 to set globally.}
 
 \item{yearsByVariable}{A numeric vector. The years to be marked in the plots.
-Use \code{options(mip.yearsByVariable=<value>)} to set globally.}
+As default it uses the value globally set by \code{options(mip.yearsBarPlot=<value>)}.}
 }
 \value{
 \code{NULL} is returned invisible.
@@ -62,7 +62,7 @@ chosen via \code{histRefModel}.
 \examples{
 \dontrun{
 options(mip.mainReg = "World")
-options(mip.yearsByVariable = c(2010, 2030, 2050, 2100))
+options(mip.yearsBarPlot = c(2010, 2030, 2050, 2100))
 options(mip.histRefModel = c("GDP|PPP pCap" = "James_IMF"))
 data <- as.quitte(data)
 vars <- c(

--- a/man/showMultiLinePlotsByVariable.Rd
+++ b/man/showMultiLinePlotsByVariable.Rd
@@ -9,8 +9,10 @@ showMultiLinePlotsByVariable(
   vars,
   xVar,
   scales = "free_y",
+  showHistorical = FALSE,
   mainReg = getOption("mip.mainReg"),
-  histRefModel = getOption("mip.histRefModel")
+  histRefModel = getOption("mip.histRefModel"),
+  yearsByVariable = getOption("mip.yearsByVariable")
 )
 }
 \arguments{
@@ -23,12 +25,19 @@ quitte object.}
 
 \item{scales}{A single string. choose either \code{"free_y"} or \code{"fixed"}.}
 
+\item{showHistorical}{A single logical value. Should historical data be
+shown? It is not recommended to set this to \code{TRUE} as the resulting
+plot we probably be quite confusing.}
+
 \item{mainReg}{A single string. The plots for this region are shown enlarged.
 Use \code{options(mip.mainReg=<value>)} to set globally.}
 
-\item{histRefModel}{A named character vector identifying the unique model to be
-chosen for historical data. Use \code{options(mip.histRefModel=<value>)} to
-set globally.}
+\item{histRefModel}{A named character vector identifying the unique model to
+be chosen for historical data. Use \code{options(mip.histRefModel=<value>)}
+to set globally.}
+
+\item{yearsByVariable}{A numeric vector. The years to be marked in the plots.
+Use \code{options(mip.yearsByVariable=<value>)} to set globally.}
 }
 \value{
 \code{NULL} is returned invisible.
@@ -53,6 +62,8 @@ chosen via \code{histRefModel}.
 \examples{
 \dontrun{
 options(mip.mainReg = "World")
+options(mip.yearsByVariable = c(2010, 2030, 2050, 2100))
+options(mip.histRefModel = c("GDP|PPP pCap" = "James_IMF"))
 data <- as.quitte(data)
 vars <- c(
   "FE|Transport pCap",


### PR DESCRIPTION
`showMultiLinePlotsByVariable()` now shows markers for certain years. By default the years are taken form `getOption("mip.yearsBarPlot")`, which is already in use in `showAreaAndBarPlots()`.

By default `showMultiLinePlotsByVariable()` does not show historical data anymore.