### PR TITLE
allow to pass alternatives to scales=free_y to showAreaAndBarPlots

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '26835340'
+ValidationKey: '26879684'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mip: Comparison of multi-model runs",
-  "version": "0.139.0",
+  "version": "0.139.1",
   "description": "<p>Package contains generic functions to produce comparison\n    plots of multi-model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.139.0
-Date: 2022-11-10
+Version: 0.139.1
+Date: 2022-11-28
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/showAreaAndBarPlots.R
+++ b/R/showAreaAndBarPlots.R
@@ -33,6 +33,7 @@
 #'   Use \code{options(mip.mainReg=<value>)} to set globally.
 #' @param yearsBarPlot A numeric vector. The years shown in the bar plots. Use
 #'   \code{options(mip.yearsBarPlot=<value>)} to set globally.
+#' @param scales adjusts how axes are harmonized. Default is free_y
 #' @return \code{NULL} is returned invisible.
 #' @section Example Plots:
 #' \if{html}{page 1 - \code{fill=FALSE}: \figure{showAreaAndBarPlots1.png}{options: width="100\%"}}
@@ -59,7 +60,8 @@ showAreaAndBarPlots <- function(
   data, vars, tot = NULL, fill = FALSE,
   orderVars = c("mean", "user", "userRev"),
   mainReg = getOption("mip.mainReg"),
-  yearsBarPlot = getOption("mip.yearsBarPlot")
+  yearsBarPlot = getOption("mip.yearsBarPlot"),
+  scales = "free_y"
 ) {
 
   data <- as.quitte(data)
@@ -120,7 +122,7 @@ showAreaAndBarPlots <- function(
   p1 <- d %>%
     filter(.data$region == .env$mainReg) %>%
     droplevels() %>%
-    mipArea(scales = "free_y", total = is.null(tot)) +
+    mipArea(scales = scales, total = is.null(tot)) +
     ylab(NULL) +
     theme(legend.position = "none")
   p2 <- d %>%
@@ -138,7 +140,7 @@ showAreaAndBarPlots <- function(
   p4 <- d %>%
     filter(.data$region != .env$mainReg) %>%
     droplevels() %>%
-    mipArea(scales = "free_y", total = is.null(tot)) +
+    mipArea(scales = scales, total = is.null(tot)) +
     guides(fill = guide_legend(reverse = TRUE))
 
   # Add black lines in area plots from variable tot if provided.

--- a/R/showAreaAndBarPlotsPlus.R
+++ b/R/showAreaAndBarPlotsPlus.R
@@ -1,6 +1,6 @@
 #' Show Area and Bar Plots Utilizing '+'-Notation
 #'
-#' Automatically infers disaggregation of a variable using the '+'-notaion and
+#' Automatically infers disaggregation of a variable using the '+'-notation and
 #' calls \code{\link{showAreaAndBarPlots}}.
 #'
 #' The function requires \code{data} to have a character column named
@@ -24,7 +24,8 @@
 showAreaAndBarPlotsPlus <- function(
   data, tot, plusNum = 1, fill = FALSE,
   mainReg = getOption("mip.mainReg"),
-  yearsBarPlot = getOption("mip.yearsBarPlot")
+  yearsBarPlot = getOption("mip.yearsBarPlot"),
+  scales = "free_y"
 ) {
 
   data <- as.quitte(data)
@@ -46,5 +47,6 @@ showAreaAndBarPlotsPlus <- function(
   # Instead:
   vars <- gsub("\\|\\++\\|", "|", varsPlus)
 
-  showAreaAndBarPlots(data, vars, tot = tot, fill = fill, mainReg = mainReg, yearsBarPlot = yearsBarPlot)
+  showAreaAndBarPlots(data, vars, tot = tot, fill = fill, mainReg = mainReg,
+                      yearsBarPlot = yearsBarPlot, scales = scales)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.139.0**
+R package **mip**, version **0.139.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P (2022). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.139.0, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P (2022). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.139.1, <URL: https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.139.0},
+  note = {R package version 0.139.1},
   doi = {10.5281/zenodo.1158586},
   url = {https://github.com/pik-piam/mip},
 }

--- a/man/showAreaAndBarPlots.Rd
+++ b/man/showAreaAndBarPlots.Rd
@@ -11,7 +11,8 @@ showAreaAndBarPlots(
   fill = FALSE,
   orderVars = c("mean", "user", "userRev"),
   mainReg = getOption("mip.mainReg"),
-  yearsBarPlot = getOption("mip.yearsBarPlot")
+  yearsBarPlot = getOption("mip.yearsBarPlot"),
+  scales = "free_y"
 )
 }
 \arguments{
@@ -44,6 +45,8 @@ Use \code{options(mip.mainReg=<value>)} to set globally.}
 
 \item{yearsBarPlot}{A numeric vector. The years shown in the bar plots. Use
 \code{options(mip.yearsBarPlot=<value>)} to set globally.}
+
+\item{scales}{adjusts how axes are harmonized. Default is free_y}
 }
 \value{
 \code{NULL} is returned invisible.

--- a/man/showAreaAndBarPlotsPlus.Rd
+++ b/man/showAreaAndBarPlotsPlus.Rd
@@ -10,7 +10,8 @@ showAreaAndBarPlotsPlus(
   plusNum = 1,
   fill = FALSE,
   mainReg = getOption("mip.mainReg"),
-  yearsBarPlot = getOption("mip.yearsBarPlot")
+  yearsBarPlot = getOption("mip.yearsBarPlot"),
+  scales = "free_y"
 )
 }
 \arguments{
@@ -29,12 +30,14 @@ Use \code{options(mip.mainReg=<value>)} to set globally.}
 
 \item{yearsBarPlot}{A numeric vector. The years shown in the bar plots. Use
 \code{options(mip.yearsBarPlot=<value>)} to set globally.}
+
+\item{scales}{adjusts how axes are harmonized. Default is free_y}
 }
 \value{
 \code{NULL} is returned invisible.
 }
 \description{
-Automatically infers disaggregation of a variable using the '+'-notaion and
+Automatically infers disaggregation of a variable using the '+'-notation and
 calls \code{\link{showAreaAndBarPlots}}.
 }
 \details{


### PR DESCRIPTION
- this allows to harmonize the scales of the Area plots as [suggested here](https://github.com/pik-piam/remind2/issues/352)