### PR TITLE
fix showAreaAndBarPlot bug if only one single item is supplied

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '27063400'
+ValidationKey: '27084132'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mip: Comparison of multi-model runs",
-  "version": "0.140.0",
+  "version": "0.140.1",
   "description": "<p>Package contains generic functions to produce comparison\n    plots of multi-model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.140.0
-Date: 2022-12-05
+Version: 0.140.1
+Date: 2022-12-06
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 .PHONY: help build check test lint format
 .DEFAULT_GOAL = help
 
+# extracts the help text and formats it nicely
+HELP_PARSING = 'm <- readLines("Makefile");\
+				m <- grep("\#\#", m, value=TRUE);\
+				command <- sub("^([^ ]*) *\#\#(.*)", "\\1", m);\
+				help <- sub("^([^ ]*) *\#\#(.*)", "\\2", m);\
+				cat(sprintf("%-8s%s", command, help), sep="\n")'
+
 help:           ## Show this help.
-	@sed -e '/##/ !d' -e '/sed/ d' -e 's/^\([^ ]*\) *##\(.*\)/\1^\2/' \
-		$(MAKEFILE_LIST) | column -ts '^'
+	@Rscript -e $(HELP_PARSING)
 
 build:          ## Build the package using lucode2::buildLibrary()
 	Rscript -e 'lucode2::buildLibrary()'

--- a/R/showAreaAndBarPlots.R
+++ b/R/showAreaAndBarPlots.R
@@ -140,7 +140,8 @@ showAreaAndBarPlots <- function(
   p4 <- d %>%
     filter(.data$region != .env$mainReg) %>%
     droplevels() %>%
-    mipArea(scales = scales, total = is.null(tot)) +
+    mipArea(scales = scales, total = is.null(tot),
+            stack_priority = if (is.null(tot)) c("variable", "region") else "variable") +
     guides(fill = guide_legend(reverse = TRUE))
 
   # Add black lines in area plots from variable tot if provided.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.140.0**
+R package **mip**, version **0.140.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P (2022). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.140.0, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P (2022). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.140.1, <URL: https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.140.0},
+  note = {R package version 0.140.1},
   doi = {10.5281/zenodo.1158586},
   url = {https://github.com/pik-piam/mip},
 }


### PR DESCRIPTION
- problem: if you pass to `showAreaAndBarPlots` a single variable plus a total, the scripts gets confused because `mipArea` then stacks by region and the total is not plotted correctly.
- cure: if a `total` will be plotted, never stack by `region`
- this whole thing is relevant because I try to implement consistency checks for model submissions and sometimes only a single "child" variable exists.

Code to reproduce it:

```
devtools::load_all()
library(dplyr)
library(quitte)
data <- filter(quitte_example_data, variable %in% c("PE", "PE|Hydro")) %>% droplevels()
showAreaAndBarPlots(data, "PE|Hydro", "PE", mainReg = "World", yearsBarPlot = 2050)
```

old:

![image](https://user-images.githubusercontent.com/90761609/205982920-f680c09f-ec4d-4dfd-a840-c5363166f7a4.png)

new: 

![image](https://user-images.githubusercontent.com/90761609/205983007-e58e6248-c826-4542-82bc-5baf200e9651.png)
