### PR TITLE
allow to use mipBarYearData() with different models

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '27084132'
+ValidationKey: '27296190'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -28,6 +28,7 @@ jobs:
           curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
           chmod 0755 run.sh
           ./run.sh bootstrap
+          rm -f bspm_*.tar.gz
 
       - name: Enable r-universe repo, modify bspm integration
         run: |
@@ -48,6 +49,7 @@ jobs:
                 pkgs <- c(bspm::install_sys(pkgs[!pkgs %%in%% noBinaryInstallRPackages]),
                           pkgs[pkgs %%in%% noBinaryInstallRPackages])
               }
+              type <- "source"
             })
             trace(utils::install.packages, expr, print = FALSE)
           })
@@ -67,9 +69,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 3-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            2-${{ runner.os }}-usr-local-lib-R-
+            3-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9003
+    rev: v0.3.2.9007
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mip: Comparison of multi-model runs",
-  "version": "0.140.1",
+  "version": "0.141.0",
   "description": "<p>Package contains generic functions to produce comparison\n    plots of multi-model runs.<\/p>",
   "creators": [
     {
@@ -23,6 +23,9 @@
     },
     {
       "name": "Führlich, Pascal"
+    },
+    {
+      "name": "Richters, Oliver"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.140.1
-Date: 2022-12-06
+Version: 0.141.0
+Date: 2023-01-02
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),
@@ -10,7 +10,8 @@ Authors@R: c(
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),
     person("Miodrag", "Stevanovic", , "miodrag@pik-potsdam.de", role = "aut"),
     person("Stephen", "Wirth", , "wirth@pik-potsdam.de", role = "aut"),
-    person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = "aut")
+    person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = "aut"),
+    person("Oliver", "Richters", role = "aut")
   )
 Description: Package contains generic functions to produce comparison
     plots of multi-model runs.
@@ -46,4 +47,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: yes
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.140.1**
+R package **mip**, version **0.141.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,16 +47,16 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P (2022). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.140.1, <URL: https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O (2023). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.141.0, <URL: https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {mip: Comparison of multi-model runs},
-  author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich},
-  year = {2022},
-  note = {R package version 0.140.1},
+  author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters},
+  year = {2023},
+  note = {R package version 0.141.0},
   doi = {10.5281/zenodo.1158586},
   url = {https://github.com/pik-piam/mip},
 }

--- a/man/mipBarYearData.Rd
+++ b/man/mipBarYearData.Rd
@@ -22,7 +22,7 @@ mipBarYearData(
 
 \item{xlab}{x-axis text}
 
-\item{title}{title appering at the top of the plot}
+\item{title}{title appearing at the top of the plot}
 
 \item{scenario_markers}{Use markers to conserve space with long scenario
 names.  Symbols are either picked automatically (default), or can be
@@ -33,8 +33,8 @@ and 20, or a ggplot2 shape name
 use markers.}
 }
 \description{
-Function for plotting (bar-plot) MAgPIE objects and compare different scenarios,
-on the x-axis for some time steps one bar for each scenario is generated
+Function for plotting (bar-plot) MAgPIE objects and compare different scenarios
+or models, on the x-axis for some time steps one bar for each scenario/model is generated
 }
 \section{Example Plot}{
 
@@ -51,5 +51,5 @@ plotCompBarYearData(EnInv, ylab = "Energy Investments|Elec (billion US$2005/yr)"
 
 }
 \author{
-Lavinia Baumstark
+Lavinia Baumstark, Oliver Richters
 }


### PR DESCRIPTION
- If `mipBarYearData()` is called with a `quitte` object that contains different models, it currently fails.
- Now:
  - if only a single model in the data, do the same as before
  - if multiple models but a single scenario in the data, differentiate by model and use model name as plot description
  - if multiple models and scenarios, differentiate both and use "model scenario" (so "REMIND NPI") as plot description
- will be helpful for model comparison projects

Example based on quitte_example_data:
[mipBarYearData.pdf](https://github.com/pik-piam/mip/files/10277114/mipBarYearData.pdf)
