### PR TITLE
fix #56 by restoring complete names in color_set

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '27296190'
+ValidationKey: '27380455'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,6 @@
 # Run CI for R using https://eddelbuettel.github.io/r-ci/
 
-name: lucode2-check
+name: check
 
 on:
   push:
@@ -14,11 +14,11 @@ env:
   NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc", "roxygen2")'
 
 jobs:
-  lucode2-check:
+  check:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Bootstrap
         run: |
@@ -57,10 +57,10 @@ jobs:
           cat /etc/R/Rprofile.site
 
       - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mip: Comparison of multi-model runs",
-  "version": "0.141.0",
+  "version": "0.141.1",
   "description": "<p>Package contains generic functions to produce comparison\n    plots of multi-model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.141.0
-Date: 2023-01-02
+Version: 0.141.1
+Date: 2023-02-17
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build check test lint format
+.PHONY: help build check test lint lint-all format format-all install docs
 .DEFAULT_GOAL = help
 
 # extracts the help text and formats it nicely
@@ -11,18 +11,35 @@ HELP_PARSING = 'm <- readLines("Makefile");\
 help:           ## Show this help.
 	@Rscript -e $(HELP_PARSING)
 
-build:          ## Build the package using lucode2::buildLibrary()
+build:          ## Build the package using lucode2::buildLibrary().
 	Rscript -e 'lucode2::buildLibrary()'
 
 check:          ## Build documentation and vignettes, run testthat tests,
-                ## and check if code etiquette is followed using lucode2::check()
+                ## and check if code etiquette is followed using lucode2::check().
 	Rscript -e 'lucode2::check()'
 
 test:           ## Run testthat tests
 	Rscript -e 'devtools::test(show_report = TRUE)'
 
-lint:           ## Check if code etiquette is followed using lucode2::lint()
+lint:           ## Check if code etiquette is followed using lucode2::lint().
+                ## Only checks files you changed.
 	Rscript -e 'lucode2::lint()'
 
-format:         ## Apply auto-formatting to changed files and lint afterwards
+lint-all:       ## Check if code etiquette is followed using lucode2::lint().
+                ## Checks all files.
+	Rscript -e 'lucode2::lint(".")'
+
+format:         ## Apply auto-formatting to changed files and lint afterwards.
 	Rscript -e 'lucode2::autoFormat()'
+
+format-all:     ## Apply auto-formatting to all files and lint afterwards.
+	Rscript -e 'lucode2::autoFormat(files=list.files("./R", full.names = TRUE, pattern = "\\.R"))'
+
+install:        ## Install the package locally via devtools::install() after
+                ## generating NAMESPACE and docs (see docs target).
+	Rscript -e 'roxygen2::roxygenize(); devtools::install(upgrade = "never")'
+
+docs:           ## Generate the package documentation (man/*.Rd files) and
+                ## NAMESPACE via roxygen2::roxygenize(), view the generated
+                ## documentation with `?package::function`.
+	Rscript -e 'roxygen2::roxygenize()'

--- a/R/mipLineHistorical.R
+++ b/R/mipLineHistorical.R
@@ -190,6 +190,7 @@ mipLineHistorical <- function(x,x_hist=NULL,color.dim="moscen",linetype.dim=NULL
 
   # colors
   color_set <- plotstyle(sources)
+  names(color_set) <- sources
   if (!is.null(color.dim.manual)) {
     if (length(color.dim.manual) != length(color_set[model_output])) {
       stop(paste0("Number of provided colors for model data (#",length(color.dim.manual),") does not match number of items defined in color.dim (#",length(color_set[model_output]),")"))

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.141.0**
+R package **mip**, version **0.141.1**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O (2023). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.141.0, <URL: https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O (2023). _mip: Comparison of multi-model runs_. doi: 10.5281/zenodo.1158586 (URL: https://doi.org/10.5281/zenodo.1158586), R package version 0.141.1, <URL: https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.141.0},
+  note = {R package version 0.141.1},
   doi = {10.5281/zenodo.1158586},
   url = {https://github.com/pik-piam/mip},
 }


### PR DESCRIPTION
- fixes https://github.com/pik-piam/mip/issues/56
- because `plotstyle()` deletes the "unit", scenarios and models with parentheses did not work with `mipLineHistorical()`
- resetting the names of `color_set` to the correct ones fixes that