### PR TITLE
add scale option to iteration plots

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '28427256'
+ValidationKey: '28448287'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.145.2
-date-released: '2023-08-09'
+version: 0.145.3
+date-released: '2023-08-10'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.145.2
-Date: 2023-08-09
+Version: 0.145.3
+Date: 2023-08-10
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/mipIterations.R
+++ b/R/mipIterations.R
@@ -17,6 +17,8 @@
 #'                      plotly. If NULL no slider is used.
 #' @param facets        A string from names(x), defining which column is used for grouping. A small plot (facet) is
 #'                      shown for each group. If NULL facets are not used.
+#' @param facetScales   The 'scales' argument for facets (if used), defaults to 'fixed'. See help(facet_wrap) for more info.
+#'
 #' @return A list of plotly plots, if returnGgplots is TRUE a list of ggplots instead
 #' @author Pascal Führlich
 #' @seealso \code{\link{getPlotData}}
@@ -27,7 +29,8 @@
 #' @importFrom utils tail
 #' @export
 mipIterations <- function(plotData, returnGgplots = FALSE,
-                          xAxis = "year", color = NULL, slider = "iteration", facets = "region") {
+                          xAxis = "year", color = NULL, slider = "iteration", facets = "region",
+                          facetScales = "fixed") {
   nonNullArgs <- Filter(Negate(is.null), c(xAxis, color, slider, facets))
   if (any(!(nonNullArgs %in% c(names(plotData), "year", "region")))) {
     stop(
@@ -115,7 +118,7 @@ mipIterations <- function(plotData, returnGgplots = FALSE,
       theme(strip.background = element_blank())
     if (!is.null(facets)) {
       # by default create a small plot for each region; always show all facets, even if empty
-      plot <- plot + facet_wrap(facets, drop = FALSE)
+      plot <- plot + facet_wrap(facets, drop = FALSE, scales = facetScales)
     }
     if (!is.null(color) && is.numeric(plotData[[color]])) {
       plot <- plot + scale_color_gradientn(colours = rainbow(5, v = 0.8))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.145.2**
+R package **mip**, version **0.145.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O (2023). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.145.2, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O (2023). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.145.3, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.145.2},
+  note = {R package version 0.145.3},
   doi = {10.5281/zenodo.1158586},
   url = {https://github.com/pik-piam/mip},
 }

--- a/man/mipIterations.Rd
+++ b/man/mipIterations.Rd
@@ -10,7 +10,8 @@ mipIterations(
   xAxis = "year",
   color = NULL,
   slider = "iteration",
-  facets = "region"
+  facets = "region",
+  facetScales = "fixed"
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ plotly. If NULL no slider is used.}
 
 \item{facets}{A string from names(x), defining which column is used for grouping. A small plot (facet) is
 shown for each group. If NULL facets are not used.}
+
+\item{facetScales}{The 'scales' argument for facets (if used), defaults to 'fixed'. See help(facet_wrap) for more info.}
 }
 \value{
 A list of plotly plots, if returnGgplots is TRUE a list of ggplots instead


### PR DESCRIPTION
This was a user request: when using the facet option, you sometimes want free y-scales per facet because the ranges of faceted variables vary a lot. 