### PR TITLE
plotstyle() does not strip units from variable names, based on strip_units argument or plotstyle.strip_units option

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '295026826'
+ValidationKey: '29670370'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.148.21
-date-released: '2024-07-02'
+version: 0.149.0
+date-released: '2024-07-09'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Depends:
     magclass,
     quitte (>= 0.3072)
 Imports:
-    RColorBrewer,
     data.table,
     dplyr,
     ggplot2,
@@ -33,12 +32,14 @@ Imports:
     htmltools,
     lusweave (>= 1.43.2),
     plotly,
+    RColorBrewer,
     reshape2,
     rlang,
     shiny,
+    stringr,
     tidyr,
     trafficlight,
-    stringr
+    withr,
 Suggests:
     gdxrrw,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.148.21
-Date: 2024-07-02
+Version: 0.149.0
+Date: 2024-07-09
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),
@@ -49,4 +49,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: yes
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/mip-package.R
+++ b/R/mip-package.R
@@ -1,14 +1,18 @@
 #' The MIP R package
-#' 
+#'
 #' Contains the routines for plotting multi model and multi scenario comparisons
-#' 
+#'
 #' \tabular{ll}{ Package: \tab mip\cr Type: \tab Package\cr Version: \tab
 #' 7.6\cr Date: \tab 2016-06-13\cr License: \tab LGPL-3\cr LazyLoad: \tab
 #' yes\cr }
-#' 
+#'
 #' @name mip-package
 #' @aliases mip-package mip
 #' @author David Klein
-#' 
+#'
 #' Maintainer: Anastasis Giannousakis <giannou@@pik-potsdam.de>
 "_PACKAGE"
+
+ignore_unused_imports <- function() {
+  withr::with_options # used in tests
+}

--- a/R/mipArea.R
+++ b/R/mipArea.R
@@ -217,7 +217,7 @@ mipArea <- function(x, stack_priority = c("variable", "region"), total = TRUE, s
   # get the same order of colors for elements that are not defined in plotstyle.
   if (!is.factor(x[[dimToStack]])) x[[dimToStack]] <- factor(x[[dimToStack]], levels = unique(x[[dimToStack]]))
   # use plotstyle colours and labels by default
-  p <- p + scale_fill_manual(values = plotstyle(levels(x[[dimToStack]])),
+  p <- p + scale_fill_manual(values = plotstyle(levels(x[[dimToStack]]), strip_units = FALSE),
                              name   = "")
 
   # increase y-axis limits to hide all-zero data that was set to -1e-36

--- a/R/mipBarYearData.R
+++ b/R/mipBarYearData.R
@@ -98,7 +98,7 @@ mipBarYearData <- function(x, colour = NULL, ylab = NULL, xlab = NULL, title = N
   }
 
   if (is.null(colour)) {
-    colour <- plotstyle(levels(x$variable))
+    colour <- plotstyle(levels(x$variable), strip_units = FALSE)
   }
 
   # make plot

--- a/R/plotstyle.R
+++ b/R/plotstyle.R
@@ -3,6 +3,7 @@
 #' Returns a named vector (using entity names) with style codes (e.g. colors)
 #' for given entities.
 #'
+#' @md
 #' @param ... One or more strings or a vector of strings with names of entities
 #'   (regions, variable names, etc.). Units in brackets "(US$2005/GJ)" will be
 #'   ignored. If left empty all available entities will be used
@@ -21,6 +22,9 @@
 #'   entities are expanded, non-matching entities are returned as the original
 #'   expression.  Does not generate default color maps. Implies \code{plot =
 #'   FALSE} and \code{verbosity = 0}.
+#' @param strip_units If `TRUE` everything from the first opening
+#'   brace (`'('`) on is stripped from the entity names.  Defaults to `TRUE` and
+#'   can be set globally using the `plotstyle.strip_units` option.
 #' @return Plot styles for given entities
 #' @section Colors for unknown entities:
 #' \if{html}{\figure{colors.png}{options: width="100\%"}}
@@ -49,8 +53,11 @@
 #' @importFrom grDevices colorRampPalette
 #' @importFrom stats runif
 
-plotstyle <- function(..., out = "color", unknown = NULL, plot = FALSE, verbosity = getOption("plotstyle.verbosity"),
-                      regexp = FALSE) {
+plotstyle <- function(..., out = "color", unknown = NULL, plot = FALSE,
+                      verbosity = getOption("plotstyle.verbosity"),
+                      regexp = FALSE,
+                      strip_units = getOption("plotstyle.strip_units",
+                                              default = TRUE)) {
 
   luplot <- list()
   luplot$plotstyle <- read.csv2(
@@ -73,7 +80,9 @@ plotstyle <- function(..., out = "color", unknown = NULL, plot = FALSE, verbosit
     entity <- row.names(luplot$plotstyle)
   } else {
     entity[is.na(entity)] <- "NA"
-    entity <- unlist(lapply(strsplit(entity, " \\("), function(x) x[1]))
+    if (isTRUE(strip_units)) {
+      entity <- unlist(lapply(strsplit(entity, " \\("), function(x) x[1]))
+    }
   }
 
   uqEntity <- unique(entity)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.148.21**
+R package **mip**, version **0.149.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.148.21, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.149.0, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   year = {2024},
-  note = {R package version 0.148.21},
+  note = {R package version 0.149.0},
   url = {https://github.com/pik-piam/mip},
   doi = {10.5281/zenodo.1158586},
 }

--- a/tests/testthat/test-plotstyle.R
+++ b/tests/testthat/test-plotstyle.R
@@ -1,0 +1,15 @@
+test_that(
+  "plotstyle() does not strip units if told not to do so",
+  {
+    expect_identical(plotstyle("Forcing|CO2 (W/m2)"),
+                     c(`Forcing|CO2` = "#e6194B"))
+
+    expect_identical(plotstyle("Forcing|CO2 (W/m2)", strip_units = FALSE),
+                     c(`Forcing|CO2 (W/m2)` = "#e6194B"))
+
+    withr::with_options(
+      list('plotstyle.strip_units' = FALSE),
+      expect_identical(plotstyle("Forcing|CO2 (W/m2)"),
+                     c(`Forcing|CO2 (W/m2)` = "#e6194B"))
+    )
+  })


### PR DESCRIPTION
See https://github.com/pik-piam/mip/issues/54#issuecomment-2217418254

Next steps:
- add a warning triggered when units are actually stripped
- ask everybody (mostly MAgPIE folks I guess) to look out for the warning and adjust their code
- switch the default of `plotstyle.strip_units` to `FALSE`
