### PR TITLE
avoid empty legends in mipArea

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29670370'
+ValidationKey: '29693265'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.149.0
-date-released: '2024-07-09'
+version: 0.149.1
+date-released: '2024-07-11'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.149.0
-Date: 2024-07-09
+Version: 0.149.1
+Date: 2024-07-11
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/shorten_legend.R
+++ b/R/shorten_legend.R
@@ -48,8 +48,11 @@ shorten_legend <- function(x, maxchar = 20, identical_only = FALSE,  # nolint: o
   }
 
   if (! is.null(ylab)) {
+    # shorten labels by variable part of ylab
     ylabvariable <- magclass::unitsplit(ylab)$variable
-    x <- gsub("^\\|", "", gsub(ylabvariable, "", x, fixed = TRUE))
+    x_tmp <- gsub("^\\|", "", gsub(ylabvariable, "", x, fixed = TRUE))
+    # avoid empty labels
+    x <- ifelse(x_tmp == "", x, x_tmp)
   } else {
     sep_or <- paste0("\\", sep, collapse = "|")
     sep_no <- paste0("[^", paste0("\\", sep, collapse = ""), "]")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.149.0**
+R package **mip**, version **0.149.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.149.0, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.149.1, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   year = {2024},
-  note = {R package version 0.149.0},
+  note = {R package version 0.149.1},
   url = {https://github.com/pik-piam/mip},
   doi = {10.5281/zenodo.1158586},
 }

--- a/man/plotstyle.Rd
+++ b/man/plotstyle.Rd
@@ -10,7 +10,8 @@ plotstyle(
   unknown = NULL,
   plot = FALSE,
   verbosity = getOption("plotstyle.verbosity"),
-  regexp = FALSE
+  regexp = FALSE,
+  strip_units = getOption("plotstyle.strip_units", default = TRUE)
 )
 }
 \arguments{
@@ -36,7 +37,11 @@ plotstyle brewed colors}
 \item{regexp}{If \code{TRUE}, match entities as regular expressions. Matching
 entities are expanded, non-matching entities are returned as the original
 expression.  Does not generate default color maps. Implies \code{plot =
-FALSE} and \code{verbosity = 0}.}
+  FALSE} and \code{verbosity = 0}.}
+
+\item{strip_units}{If \code{TRUE} everything from the first opening
+brace (\code{'('}) on is stripped from the entity names.  Defaults to \code{TRUE} and
+can be set globally using the \code{plotstyle.strip_units} option.}
 }
 \value{
 Plot styles for given entities


### PR DESCRIPTION
- It happens if the parent variable name is `Emi (w/bunkers)` and the child is `Emi`. Then, the fact that `shorten_legend` removes what it thinks is a unit (but isn't) and strips away all the variable name, leaving an empty string.
- If shortening leads to `""`, better take the full name.

old:
![image](https://github.com/pik-piam/mip/assets/90761609/5cca3f81-d5eb-4f86-8415-b08b01b696c5)
new (no idea why it changed the color):
![image](https://github.com/pik-piam/mip/assets/90761609/10b8de0e-b9a1-4937-a751-0b0c6f530aa6)
