### PR TITLE
Logarithmic scale for showMultiLinePlotsByVariable

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29964000'
+ValidationKey: '30175840'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.150.0
-date-released: '2024-09-10'
+version: 0.151.0
+date-released: '2024-09-18'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.150.0
-Date: 2024-09-10
+Version: 0.151.0
+Date: 2024-09-18
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/showMultiLinePlotsByVariable.R
+++ b/R/showMultiLinePlotsByVariable.R
@@ -21,6 +21,8 @@
 #'   to set globally.
 #' @param yearsByVariable A numeric vector. The years to be marked in the plots.
 #'   As default it uses the value globally set by \code{options(mip.yearsBarPlot=<value>)}.
+#' @param logscale A string such as "x", "y" or "xy". Each axis mentioned in this string
+#'   is displayed in logarithmic scale (base 10) instead of linear.
 #' @inheritParams showMultiLinePlots
 #' @return \code{NULL} is returned invisible.
 #' @section Example Plots:
@@ -49,109 +51,118 @@ showMultiLinePlotsByVariable <- function(
   nrowNum = 1, 
   mainReg = getOption("mip.mainReg"),
   histRefModel = getOption("mip.histRefModel"),
-  yearsByVariable = getOption("mip.yearsBarPlot")
+  yearsByVariable = getOption("mip.yearsBarPlot"),
+  logscale = ""
 ) {
+	# validate function arguments
+	stopifnot(is.character(vars))
+	stopifnot(is.character(xVar) && length(xVar) == 1)
+	stopifnot(is.character(scales) && length(scales) == 1)
+	stopifnot(is.character(logscale) && length(logscale) == 1)
+	stopifnot(identical(showHistorical, TRUE) || identical(showHistorical, FALSE))
+	stopifnot(is.null(yearsByVariable) || is.numeric(yearsByVariable))
+	checkGlobalOptionsProvided(c("mainReg", "histRefModel"))
+	stopifnot(is.character(mainReg) && length(mainReg) == 1)
+	stopifnot(is.character(histRefModel) && !is.null(names(histRefModel)))
 
-  data <- as.quitte(data)
 
-  # Validate function arguments.
-  stopifnot(is.character(vars))
-  stopifnot(is.character(xVar) && length(xVar) == 1)
-  stopifnot(is.character(scales) && length(scales) == 1)
-  stopifnot(identical(showHistorical, TRUE) || identical(showHistorical, FALSE))
-  stopifnot(is.null(yearsByVariable) || is.numeric(yearsByVariable))
-  checkGlobalOptionsProvided(c("mainReg", "histRefModel"))
-  stopifnot(is.character(mainReg) && length(mainReg) == 1)
-  stopifnot(is.character(histRefModel) && !is.null(names(histRefModel)))
+	# keep and match relevant variables
+	data <- as.quitte(data)
+	dy <- data %>%
+		filter(.data$variable %in% .env$vars)
+	dx <- data %>%
+		filter(.data$variable %in% .env$xVar) %>%
+		filter(.data$scenario != "historical" | .data$model == .env$histRefModel[.env$xVar])
+	d <- dy %>%
+		left_join(dx, by = c("scenario", "region", "period"), suffix = c("", ".x") ) %>%
+		drop_na(.data$value, .data$value.x) %>%
+		filter(if (grepl("x", logscale)) .data$value.x > 0 else TRUE) %>% # if logscale x, drop zeroes
+		filter(if (grepl("y", logscale)) .data$value   > 0 else TRUE) %>% # if logscale y, drop zeroes
+		arrange(.data$period) %>% droplevels()
 
-  dy <- data %>%
-    filter(.data$variable %in% .env$vars)
-  dx <- data %>%
-    filter(.data$variable %in% .env$xVar) %>%
-    filter(.data$scenario != "historical" | .data$model == .env$histRefModel[.env$xVar])
-  d <- dy %>%
-    left_join(dx, by = c("scenario", "region", "period"), suffix = c("", ".x")) %>%
-    drop_na(.data$value, .data$value.x) %>%
-    arrange(.data$period) %>%
-    droplevels()
-  dMainScen <- d %>%
-    filter(.data$region == .env$mainReg, .data$scenario != "historical") %>%
-    droplevels()
-  dMainHist <- d %>%
-    filter(.data$region == .env$mainReg, .data$scenario == "historical") %>%
-    droplevels()
-  dRegiScen <- d %>%
-    filter(.data$region != .env$mainReg, .data$scenario != "historical") %>%
-    droplevels()
-  dRegiHist <- d %>%
-    filter(.data$region != .env$mainReg, .data$scenario == "historical") %>%
-    droplevels()
 
-  regions <- levels(dRegiScen$region)
+	# prepare plotting
+	label <- paste0("(", paste0(levels(d$unit), collapse = ","), ")")
+	xLabel <- paste0(xVar, " (", paste0(levels(d$unit.x), collapse = ","), ")")
 
-  warnMissingVars(dMainScen, vars)
-  if (NROW(dMainScen) == 0) {
-    warning("Nothing to plot.", call. = FALSE)
-    return(invisible(NULL))
-  }
+	logscaleRange <- function(dataValues) c(floor(log10(min(dataValues))*10)/10, ceiling(log10(max(dataValues))*10)/10)
+	logscaleBreaks <- function(dataValues) {
+		majorBreaks <- 10^seq(floor(log10(min(dataValues))), ceiling(log10(max(dataValues))), 1) # 10 100 1000
+		minorBreaks <- as.vector(outer(1:9, head(majorBreaks,-1), "*")) # 10 20 .. 90 100 200 .. 900 
+		if(diff(logscaleRange(dataValues)) < 3) majorBreaks <- minorBreaks
+		return(list(majorBreaks, minorBreaks))
+	}
 
-  label <- paste0("(", paste0(levels(d$unit), collapse = ","), ")")
-  xLabel <- paste0(xVar, " (", paste0(levels(d$unit.x), collapse = ","), ")")
-  
-  if (showGlobal) {
-    p1 <- dMainScen %>%
-      ggplot(aes(.data$value.x, .data$value)) +
-      geom_line(aes(linetype = .data$scenario)) +
-      facet_wrap(vars(.data$variable), scales = scales, nrow = nrowNum) +
-      theme_minimal() +
-      expand_limits(y = 0) +
-      ylab(label) + xlab(xLabel)
-  }
-  p2 <- dRegiScen %>%
-    ggplot(aes(.data$value.x, .data$value, color = .data$region)) +
-    geom_line(aes(linetype = .data$scenario)) +
-    facet_wrap(vars(.data$variable), scales = scales, nrow = nrowNum) +
-    theme_minimal() +
-    scale_color_manual(values = plotstyle(regions)) +
-    expand_limits(y = 0) +
-    ylab(label) + xlab(xLabel)
-  
-  if (showHistorical) {
-    stopifnot(xVar %in% names(histRefModel))
-    if (showGlobal) {
-      p1 <- p1 +
-        geom_point(data = dMainHist, aes(shape = .data$model)) +
-        geom_line(data = dMainHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5)
-    }
-    p2 <- p2 +
-      geom_point(data = dRegiHist, aes(shape = .data$model)) +
-      geom_line(data = dRegiHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5)
-  }
-  # Add markers for certain years.
-  if (length(yearsByVariable) > 0) {
-    if (showGlobal) {
-      p1 <- p1 +
-        geom_point(
-        data = dMainScen %>%
-          filter(.data$period %in% .env$yearsByVariable) %>%
-          mutate(year = factor(.data$period)),
-        mapping = aes(.data$value.x, .data$value, shape = .data$year))
-    }
-    p2 <- p2 +
-      geom_point(
-        data = dRegiScen %>%
-          filter(.data$period %in% .env$yearsByVariable) %>%
-          mutate(year = factor(.data$period)),
-        mapping = aes(.data$value.x, .data$value, shape = .data$year))
-  }
+	plotOptions <- function(dataOptions)
+		dataOptions %>% ggplot(aes(.data$value.x, .data$value)) +
+		geom_line(aes(linetype = .data$scenario)) +
+		facet_wrap(vars(.data$variable), scales = scales, nrow = nrowNum) +
+		theme_minimal() +
+		ylab(label) +
+		xlab(xLabel) +
+		list(
+			# year markers
+			if(length(yearsByVariable) > 0)
+				geom_point(mapping = aes(.data$value.x, .data$value, shape = .data$year),
+					data = dataOptions %>%
+						filter(.data$period %in% .env$yearsByVariable) %>%
+						mutate(year = factor(.data$period))),
+			# logscale
+			if(grepl("x", logscale))
+				logscaleBreaks(dataOptions$value.x) %>% { scale_x_log10(breaks = first(.), minor_breaks = last(.)) },
+			if(grepl("y", logscale))
+				logscaleBreaks(dataOptions$value) %>% { scale_y_log10(breaks = first(.), minor_breaks = last(.)) },
+			# axis limits
+			if(grepl("x", logscale)) expand_limits(x = 10^logscaleRange(dataOptions$value.x)),
+			if(grepl("y", logscale)) expand_limits(y = 10^logscaleRange(dataOptions$value))
+			else					 expand_limits(y = 0)
+		)
 
-  # Show plots.
-  if (showGlobal) { 
-    print(p1)
-    cat("\n\n")
-  }
-  print(p2)
-  cat("\n\n")
+	
+	# plot global or main region data
+	if (showGlobal) {
+		dMainScen <- d %>% filter(.data$region == .env$mainReg, .data$scenario != "historical") %>% droplevels()
+		warnMissingVars(dMainScen, vars)
+		if (NROW(dMainScen) == 0) {
+			warning("Nothing to plot.", call. = FALSE)
+			return(invisible(NULL))
+		}
+		plotGlobal <- dMainScen %>% plotOptions()
+	}
 
-  return(invisible(NULL))
+
+	# plot other regions
+	dRegiScen <- d %>% filter(.data$region != .env$mainReg, .data$scenario != "historical") %>% droplevels()
+	regions <- levels(dRegiScen$region)
+	plotRegi <- dRegiScen %>% plotOptions() +
+		aes(color = .data$region) + 
+		scale_color_manual(values = plotstyle(regions))
+	
+
+	# add historical data 
+	if (showHistorical) {
+		stopifnot(xVar %in% names(histRefModel))
+
+		plotOptionsHist <- function(dataHist)
+			geom_point(data = dataHist, aes(shape = .data$model)) +
+			geom_line(data = dataHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5)
+
+		if (showGlobal) {
+			dMainHist <- d %>% filter(.data$region == .env$mainReg, .data$scenario == "historical") %>% droplevels()
+			plotGlobal <- plotGlobal + plotOptionsHist(dMainHist)
+		}
+
+		dRegiHist <- d %>% filter(.data$region != .env$mainReg, .data$scenario == "historical") %>% droplevels()
+		plotRegi <- plotRegi + plotOptionsHist(dRegiHist)
+	}
+
+
+	# show plots
+	if (showGlobal) {
+		print(plotGlobal)
+		cat("\n\n")
+	}
+	print(plotRegi)
+	cat("\n\n")
+	return(invisible(NULL))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.150.0**
+R package **mip**, version **0.151.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.150.0, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.151.0, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   year = {2024},
-  note = {R package version 0.150.0},
+  note = {R package version 0.151.0},
   url = {https://github.com/pik-piam/mip},
   doi = {10.5281/zenodo.1158586},
 }

--- a/man/showMultiLinePlotsByVariable.Rd
+++ b/man/showMultiLinePlotsByVariable.Rd
@@ -14,7 +14,8 @@ showMultiLinePlotsByVariable(
   nrowNum = 1,
   mainReg = getOption("mip.mainReg"),
   histRefModel = getOption("mip.histRefModel"),
-  yearsByVariable = getOption("mip.yearsBarPlot")
+  yearsByVariable = getOption("mip.yearsBarPlot"),
+  logscale = ""
 )
 }
 \arguments{
@@ -45,6 +46,9 @@ to set globally.}
 
 \item{yearsByVariable}{A numeric vector. The years to be marked in the plots.
 As default it uses the value globally set by \code{options(mip.yearsBarPlot=<value>)}.}
+
+\item{logscale}{A string such as "x", "y" or "xy". Each axis mentioned in this string
+is displayed in logarithmic scale (base 10) instead of linear.}
 }
 \value{
 \code{NULL} is returned invisible.


### PR DESCRIPTION
showMultiLinePlotsByVariable has now an optional parameter logscale, a string that can be:
- empty (default)
- "x" and the horizontal axis takes a log10 scale
- "y" and the vertical axis takes a log10 scale
- "xy" 

The two images below represent the same data, but the one with loglog is easier to read.
![image](https://github.com/user-attachments/assets/44961b20-5618-49b2-bae2-e2fa28f49a38)
![image](https://github.com/user-attachments/assets/841e1495-579d-41cb-b07a-81547611ff32)
