### PR TITLE
have plotstyle() and  plotstyle.add() use a per-session cache instead of messing with files

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '30203379'
+ValidationKey: '303332517063'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
@@ -12,3 +12,4 @@ AcceptedNotes:
 AutocreateReadme: yes
 allowLinterWarnings: yes
 enforceVersionUpdate: no
+skipCoverage: no

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.151.1
-date-released: '2024-09-23'
+version: 0.151.1.9001
+date-released: '2024-12-06'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.151.1
-Date: 2024-09-23
+Version: 0.151.1.9001
+Date: 2024-12-06
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.151.1**
+R package **mip**, version **0.151.1.9001**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.151.1, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2024). _mip: Comparison of multi-model runs_. doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, R package version 0.151.1.9001, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   year = {2024},
-  note = {R package version 0.151.1},
+  note = {R package version 0.151.1.9001},
   url = {https://github.com/pik-piam/mip},
   doi = {10.5281/zenodo.1158586},
 }


### PR DESCRIPTION
- `plotstyle()` and `plotstyle.add()` use a per-session cache for plot styles.
- The cache is initialised from `./inst/extdata/plotstyles.csv`.
- Calling `plotstyle.add()` changes the per-session cache, to allow for all subsequent calls to `mip` functions to use the defined plot styles, but does not modify any files, to prevent changes from affecting other users on the cluster (see linked issues).
- To update plot styles permanentyl, call `plotstyle.add(write_file = TRUE)` and use the resulting file in updating, building, and distributing a new package version.

close #114
close pik-piam/remind2#675