### PR TITLE
Adding arguments required by the shinyresults QOL update

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '30808080'
+ValidationKey: '31047940'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31047940'
+ValidationKey: '31063340'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31063340'
+ValidationKey: '31064880'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,15 +35,6 @@ jobs:
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install python dependencies if applicable
-        run: |
-          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
-          [ -f requirements.txt ] && pip install -r requirements.txt || true
-
       - name: Run pre-commit checks
         shell: bash
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'mip: Comparison of multi-model runs'
 version: 0.154.0
-date-released: '2025-03-14'
+date-released: '2025-03-24'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'mip: Comparison of multi-model runs'
 version: 0.154.0
-date-released: '2025-03-24'
+date-released: '2025-03-25'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.153.0
-date-released: '2025-02-17'
+version: 0.154.0
+date-released: '2025-03-14'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: mip
 Title: Comparison of multi-model runs
 Version: 0.154.0
-Date: 2025-03-14
+Date: 2025-03-24
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: mip
 Title: Comparison of multi-model runs
 Version: 0.154.0
-Date: 2025-03-24
+Date: 2025-03-25
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.153.0
-Date: 2025-02-17
+Version: 0.154.0
+Date: 2025-03-14
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/mipArea.R
+++ b/R/mipArea.R
@@ -16,6 +16,7 @@
 #' objects, the dimension that contains the variables must have one of the following names: variable, scenario, model.
 #' @param hist_source If there are multiple historical sources the name of the source that you want to be plotted.
 #' @param ylab y-axis text
+#' @param transpose Transposes the facet grid, swapping scenarios and regions being the horizontal and vertical axes.
 #' @author David Klein, Jan Philipp Dietrich
 #' @section Example Plot:
 #' \if{html}{\figure{mipArea.png}{example plot}}
@@ -38,7 +39,7 @@
 #' @importFrom rlang .data
 #' @export
 mipArea <- function(x, stack_priority = c("variable", "region"), total = TRUE, scales = "fixed", shorten = TRUE, #nolint
-                    hist = NULL, hist_source = "first", ylab = NULL) { #nolint
+                    hist = NULL, hist_source = "first", ylab = NULL, transpose = FALSE) { #nolint
   ############################################
   ######  P R E P A R E   D A T A  ###########
   ############################################
@@ -187,10 +188,17 @@ mipArea <- function(x, stack_priority = c("variable", "region"), total = TRUE, s
 
 
   # define facet_grid
-  if (length(facets) == 1) p <- p + facet_wrap(as.formula(paste("~", facets)), scales = scales)
-  if (length(facets) == 2) p <- p + facet_grid(as.formula(paste(facets[1], "~", facets[2])), scales = scales)
-  # facet 1 and 2 are combined in dim 1
-  if (length(facets) == 3) p <- p + facet_grid(as.formula(paste(facets[1], "~", facets[3])), scales = scales)
+  if (!transpose) {
+    if (length(facets) == 1) p <- p + facet_wrap(as.formula(paste("~", facets)), scales = scales)
+    if (length(facets) == 2) p <- p + facet_grid(as.formula(paste(facets[1], "~", facets[2])), scales = scales)
+    # facet 1 and 2 are combined in dim 1
+    if (length(facets) == 3) p <- p + facet_grid(as.formula(paste(facets[1], "~", facets[3])), scales = scales)
+  } else {
+    if (length(facets) == 1) p <- p + facet_wrap(as.formula(paste(facets,"~")), scales = scales)
+    if (length(facets) == 2) p <- p + facet_grid(as.formula(paste(facets[2], "~", facets[1])), scales = scales)
+    # facet 1 and 2 are combined in dim 1
+    if (length(facets) == 3) p <- p + facet_grid(as.formula(paste(facets[3], "~", facets[1])), scales = scales)
+  }
 
   # add total to plot as black line
   if (is.quitte(total)) {

--- a/R/mipLineHistorical.R
+++ b/R/mipLineHistorical.R
@@ -24,6 +24,7 @@
 #' @param xlim        x axis limits as vector with min and max year
 #' @param facet.ncol  number of columns used for faceting, default=3.
 #' @param legend.ncol number of columns used in legends, default=1.
+#' @param legend.pos  position of the legend, default="bottom".
 #' @param hlines optional horizontal lines to be added to the plot, Allowed data formats: magpie, Default is \code{NULL}.
 #' @param hlines.labels optional labels for horizontal lines, Allowed data formats: named vector, where each name corresponds to exactly one variable in hlines, Default is \code{NULL}.
 #' @param color.dim.manual optional vector with manual colors replacing default colors of color.dim, default is \code{NULL}.
@@ -55,7 +56,8 @@ mipLineHistorical <- function(x, x_hist = NULL, color.dim = "identifier", linety
                               ylog = NULL, size = 14, scales = "fixed",
                               leg.proj = FALSE, plot.priority = c("x", "x_hist", "x_proj"),
                               ggobject = TRUE, paper_style = FALSE, xlim = NULL,
-                              facet.ncol = 3, legend.ncol = 1, hlines = NULL, hlines.labels = NULL,
+                              facet.ncol = 3, legend.ncol = 1, legend.pos = "bottom",
+                              hlines = NULL, hlines.labels = NULL,
                               color.dim.manual = NULL, color.dim.manual.hist = NULL) {
   x <- as.quitte(x)
 
@@ -265,8 +267,9 @@ mipLineHistorical <- function(x, x_hist = NULL, color.dim = "identifier", linety
       axis.text.y = element_text(size = text_size, colour = "black"),
       axis.title.x = element_text(size = text_size, face = "bold", vjust = -0.3),
       axis.text.x = element_text(size = text_size, angle = 90, hjust = .5, colour = "black"),
-      legend.position = "bottom",
+      legend.position = legend.pos,
       legend.direction = "horizontal",
+      legend.justification = "top",
       legend.title = element_text(size = text_size, face = "bold", hjust = 0),
       legend.text = element_text(size = text_size - 2),
       legend.key = element_blank(),

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   doi = {10.5281/zenodo.1158586},
-  date = {2025-03-24},
+  date = {2025-03-25},
   year = {2025},
   url = {https://github.com/pik-piam/mip},
   note = {Version: 0.154.0},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.153.0**
+R package **mip**, version **0.154.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.153.0, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.154.0, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   doi = {10.5281/zenodo.1158586},
-  date = {2025-02-17},
+  date = {2025-03-14},
   year = {2025},
   url = {https://github.com/pik-piam/mip},
-  note = {Version: 0.153.0},
+  note = {Version: 0.154.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   doi = {10.5281/zenodo.1158586},
-  date = {2025-03-14},
+  date = {2025-03-24},
   year = {2025},
   url = {https://github.com/pik-piam/mip},
   note = {Version: 0.154.0},

--- a/man/mipArea.Rd
+++ b/man/mipArea.Rd
@@ -12,7 +12,8 @@ mipArea(
   shorten = TRUE,
   hist = NULL,
   hist_source = "first",
-  ylab = NULL
+  ylab = NULL,
+  transpose = FALSE
 )
 }
 \arguments{
@@ -39,6 +40,8 @@ objects, the dimension that contains the variables must have one of the followin
 \item{hist_source}{If there are multiple historical sources the name of the source that you want to be plotted.}
 
 \item{ylab}{y-axis text}
+
+\item{transpose}{Transposes the facet grid, swapping scenarios and regions being the horizontal and vertical axes.}
 }
 \description{
 Generic area plot function. Automatically creates facet grid from data. Optionally adds total line.

--- a/man/mipLineHistorical.Rd
+++ b/man/mipLineHistorical.Rd
@@ -28,6 +28,7 @@ mipLineHistorical(
   xlim = NULL,
   facet.ncol = 3,
   legend.ncol = 1,
+  legend.pos = "bottom",
   hlines = NULL,
   hlines.labels = NULL,
   color.dim.manual = NULL,
@@ -81,6 +82,8 @@ If no historic information is provided the plot will ignore it.}
 \item{facet.ncol}{number of columns used for faceting, default=3.}
 
 \item{legend.ncol}{number of columns used in legends, default=1.}
+
+\item{legend.pos}{position of the legend, default="bottom".}
 
 \item{hlines}{optional horizontal lines to be added to the plot, Allowed data formats: magpie, Default is \code{NULL}.}
 


### PR DESCRIPTION
added legend.pos argument to mipLineHistorical and transpose argument to mipArea

`legend.pos`: allows changing the legend position, where `"bottom"` is the (currently hardcoded) default, and `"right"` is useful when too many scenarios are selected.

`transpose`: tranposes the facet grid between scenarios and regions being vertical/horizontal