### PR TITLE
fix bug in mipArea

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31064880'
+ValidationKey: '31086593'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.154.0
-date-released: '2025-03-25'
+version: 0.154.1
+date-released: '2025-03-26'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.154.0
-Date: 2025-03-25
+Version: 0.154.1
+Date: 2025-03-26
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/mipArea.R
+++ b/R/mipArea.R
@@ -57,10 +57,8 @@ mipArea <- function(x, stack_priority = c("variable", "region"), total = TRUE, s
   if (all(is.na(x$scenario))) x$scenario <- "default"
 
   # if not given derive y-axis label, shorten variables accordingly
-  if (is.null(ylab)) {
-    shortenedVariables <- shorten_legend(x$variable, identical_only = TRUE, unit = x$unit)
-    ylab <- attr(shortenedVariables, "ylab")
-  }
+  shortenedVariables <- shorten_legend(x$variable, identical_only = TRUE, unit = x$unit)
+  ylab <- attr(shortenedVariables, "ylab")
 
   # Repeat the same for history
   if (!is.null(hist)) {
@@ -185,7 +183,6 @@ mipArea <- function(x, stack_priority = c("variable", "region"), total = TRUE, s
     p <- p + geom_area(data = posH, aes_(~period, ~value, fill = as.formula(paste("~", dimToStack))), alpha = 0.3)
     p <- p + geom_area(data = negH, aes_(~period, ~value, fill = as.formula(paste("~", dimToStack))), alpha = 0.3)
   }
-
 
   # define facet_grid
   if (!transpose) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.154.0**
+R package **mip**, version **0.154.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.154.0, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.154.1, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   doi = {10.5281/zenodo.1158586},
-  date = {2025-03-25},
+  date = {2025-03-26},
   year = {2025},
   url = {https://github.com/pik-piam/mip},
-  note = {Version: 0.154.0},
+  note = {Version: 0.154.1},
 }
 ```


### PR DESCRIPTION
This fixes https://github.com/pik-piam/mip/issues/127 by ensuring, that the parameter `shorten` to `mipArea` works together with `plotstyle` (i.e. it is not necessary to enter both the truncated and original variable to the plotstyle dictionary) 