### PR TITLE
Fix too large verbatim blocks

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31094298'
+ValidationKey: '31277928'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.154.1
-date-released: '2025-03-31'
+version: 0.154.2
+date-released: '2025-07-15'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.154.1
-Date: 2025-03-31
+Version: 0.154.2
+Date: 2025-07-15
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/validationpdf.R
+++ b/R/validationpdf.R
@@ -412,13 +412,19 @@ validationpdf <- function(x,hist,file="validation.pdf",style="comparison", only_
     }
     if(length(xtrax)>0 | length(xtrahist)>0) {
       swlatex(sw,"\\section{Non-Matching Data}")
+      # We switch to small font size, as the long verbatim lists
+      # are too large for LaTeX
       if(length(xtrax)>0) {
         swlatex(sw,"\\subsection{Model outputs}")
+        swlatex(sw,"\\small")
         swR(sw,cat,xtrax,sep="\n")
+        swlatex(sw,"\\normalsize")
       }
       if(length(xtrahist)>0) {
         swlatex(sw,"\\subsection{Validation data}")
+        swlatex(sw,"\\small")
         swR(sw,cat,xtrahist,sep="\n")
+        swlatex(sw,"\\normalsize")
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.154.1**
+R package **mip**, version **0.154.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.154.1, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.154.2, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   doi = {10.5281/zenodo.1158586},
-  date = {2025-03-31},
+  date = {2025-07-15},
   year = {2025},
   url = {https://github.com/pik-piam/mip},
-  note = {Version: 0.154.1},
+  note = {Version: 0.154.2},
 }
 ```


### PR DESCRIPTION
The verbatim list generated in the non-matching data subsections are too large for LaTeX to handle. Thus, this PR changes the font size for these lists to \small, which makes them renderable again.