### PR TITLE
fix bug in plotstyle function

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31277928'
+ValidationKey: '31312099'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.154.2
-date-released: '2025-07-15'
+version: 0.154.3
+date-released: '2025-07-24'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.154.2
-Date: 2025-07-15
+Version: 0.154.3
+Date: 2025-07-24
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/plotstyle.R
+++ b/R/plotstyle.R
@@ -55,6 +55,8 @@
 
 plotstyle <- (function()
 {
+
+
   cache <- new.env(parent = emptyenv())
   cache$ps <- read.csv2(
     system.file("extdata", "plotstyle.csv", package = "mip"),
@@ -68,9 +70,15 @@ plotstyle <- (function()
                                    default = TRUE)) {
 
     luplot <- list()
-    luplot$plotstyle <- getElement(get('cache', envir = environment(plotstyle),
-                                       inherits = FALSE),
-                                   'ps')
+
+    # read in plot styles
+    # if user has modified settings locally, read from session cache,
+    # otherwise read in plotstyle.csv
+    if ("ps" %in% names(environment(plotstyle))) {
+      luplot$plotstyle <- get("ps", envir = environment(plotstyle))
+    } else {
+      luplot$plotstyle <- getElement(get("cache", envir = environment(plotstyle), inherits = FALSE), "ps")
+    }
 
     if (is.null(out)) {
       out <- "color"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.154.2**
+R package **mip**, version **0.154.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.154.2, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T (2025). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.154.3, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter},
   doi = {10.5281/zenodo.1158586},
-  date = {2025-07-15},
+  date = {2025-07-24},
   year = {2025},
   url = {https://github.com/pik-piam/mip},
-  note = {Version: 0.154.2},
+  note = {Version: 0.154.3},
 }
 ```

--- a/tests/testthat/test-plotstyle.add.R
+++ b/tests/testthat/test-plotstyle.add.R
@@ -1,0 +1,8 @@
+test_that("plotstyle.add successfully adds an entry to the session cache", {
+
+  a <- plotstyle.add("NEU",  "Other Europe", rgb(0.0, 0.0, 0.65,  1), marker = 9, replace = TRUE)
+  b <- plotstyle("NEU", out = "all")
+  expect_identical(b$color, "#0000A6FF")
+  expect_identical(b$marker, 9)
+
+})


### PR DESCRIPTION
This fixes a bug with saving settings to the local session cache in `plotstyle.add`.  If the user has made local adjustments, they were not read in before.

Before

```
a <- plotstyle.add("NEU",  "Other Europe", rgb(0.0, 0.0, 0.65,  1), marker = 9, replace = TRUE )
plotstyle("NEU", out = "all")
           legend   color marker linestyle
NEU non-EU Europe #42d4f4     NA    
```

After

```
plotstyle("NEU", out = "all")
          legend     color marker linestyle
NEU Other Europe #0000A6FF      9      <NA>
```

