### PR TITLE
Remove calculated total line from stacked area

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31598891'
+ValidationKey: '31732680'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.155.3
-date-released: '2025-09-16'
+version: 0.155.4
+date-released: '2025-11-28'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.155.3
-Date: 2025-09-16
+Version: 0.155.4
+Date: 2025-11-28
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/showAreaAndBarPlots.R
+++ b/R/showAreaAndBarPlots.R
@@ -151,10 +151,11 @@ showAreaAndBarPlots <- function(
 
   # Create plots.
   # plotAreaMain: area plot for each scenario, main region
+  # no total line plotted here, can be added below
   plotAreaMain <- dataVars %>%
     filter(.data$region == .env$mainReg) %>%
     droplevels() %>%
-    mipArea(scales = scales, total = is.null(tot), ylab = lcp) +
+    mipArea(scales = scales, total = FALSE, ylab = lcp) +
     ylab(NULL) +
     theme(legend.position = "none")
 
@@ -179,9 +180,10 @@ showAreaAndBarPlots <- function(
       guides(fill = guide_legend(reverse = TRUE, ncol = 3))
 
     # plotAreaRegi: area plot for each scenario and region
+    # no total line plotted here, can be added below
     plotAreaRegi <- dataRegi %>%
       droplevels() %>%
-      mipArea(scales = scales, total = is.null(tot), ylab = lcp,
+      mipArea(scales = scales, total = FALSE, ylab = lcp,
               stack_priority = if (is.null(tot)) c("variable", "region") else "variable") +
       guides(fill = guide_legend(reverse = TRUE))
   } else {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.155.3**
+R package **mip**, version **0.155.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mip)](https://cran.r-project.org/package=mip) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter and Robert Salzwedel and Fabrice Lécuyer},
   doi = {10.5281/zenodo.1158586},
-  date = {2025-09-16},
+  date = {2025-11-28},
   year = {2025},
   url = {https://github.com/pik-piam/mip},
-  note = {Version: 0.155.3},
+  note = {Version: 0.155.4},
 }
 ```


### PR DESCRIPTION
**TLDR**: `showAreaAndBarPlots` showed a total line that was calculated from the sum of stacked areas. I removed the line to avoid suggesting consistency that isn't backed by data. It plots a total line as before if the total variable is given.

## Before

`showAreaAndBarPlots` plots a black line as total, even tough `tot = NULL`. It is just calculated internally as the sum of all variables (i.e. stacked areas).
- This can be problematic as ist suggests that the variables add up correctly to the total, which can't be checked with this plot as the total variable doesn't come from data.
- It is also inconsistent as the bars only get a total line if the total variable was provided (as it should be).
- In this particular example below, it is even worse because the y-axis label is wrong (a particular issue with our variable names that is irrelevant to this PR). mip guessed the label from the common prefix of all variables (as no total is provided) so the black line doesn't correspond to the suggested variable from the y axis.

<p float="left">
<img width="380" alt="grafik" src="https://github.com/user-attachments/assets/f842e16d-70fb-4e2d-8da4-7605b11b66e6" />
<img width="380" alt="grafik" src="https://github.com/user-attachments/assets/99eb4154-1146-4537-b78b-8ecb97ab249e" />
</p>

## After

`showAreaAndBarPlots` no longer plots a total line on the areas unless the total variable is explicitly given. Now the area plots behave exactly like the bar plots.

<p float="left">
<img width="380" alt="grafik" src="https://github.com/user-attachments/assets/918a0ab7-1031-48ab-978d-042fc52d048b" />
<img width="380" alt="grafik" src="https://github.com/user-attachments/assets/28e77901-4fae-4f32-834a-d47f699a993d" />
</p>

Of course, the total line is still plotted as before, if you provide the total variable explicitly. I now deliberately selected a wrong total, a bug that can be identified with this plot. On the other hand, a total line that does add up would now actually give you confidence in the summation.

<p float="left">
<img width="380" alt="grafik" src="https://github.com/user-attachments/assets/6554e970-5d0a-4d2c-9a46-4b816ba7d42e" />
<img width="380" alt="grafik" src="https://github.com/user-attachments/assets/32caca68-7fb9-4f2e-939c-de57ba643ed4" />
</p>

# Code change
Inside `showAreaAndBarPlots`, `mipArea` is now always called with `total = FALSE` as the total line is added on top of the area plot afterwards. One could also remove this addition of the total line inside of `showAreaAndBarPlots` and instead pass the data of the total to `mipArea` which might be a bit cleaner.