### PR TITLE
Upgrade knitr version 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '319361056'
+ValidationKey: '32170320'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
           options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
                             CRAN = Sys.getenv('RSPM')))
           pak::pak()
-          
+
       - name: Run pre-commit checks
         shell: bash
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mip: Comparison of multi-model runs'
-version: 0.155.12
-date-released: '2026-05-15'
+version: 0.156.0
+date-released: '2026-06-18'
 abstract: Package contains generic functions to produce comparison plots of multi-model
   runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mip
 Title: Comparison of multi-model runs
-Version: 0.155.12
-Date: 2026-05-15
+Version: 0.156.0
+Date: 2026-06-18
 Authors@R: c(
     person("David", "Klein", , "dklein@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),
@@ -45,11 +45,11 @@ Imports:
     withr,
 Suggests:
     gdxrrw,
-    knitr,
+    knitr (>= 1.51.5),
     rmarkdown,
     testthat
 VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: yes
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comparison of multi-model runs
 
-R package **mip**, version **0.155.12**
+R package **mip**, version **0.156.0**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158586.svg)](https://doi.org/10.5281/zenodo.1158586) [![R build status](https://github.com/pik-piam/mip/workflows/check/badge.svg)](https://github.com/pik-piam/mip/actions) [![codecov](https://codecov.io/gh/pik-piam/mip/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mip) [![r-universe](https://pik-piam.r-universe.dev/badges/mip)](https://pik-piam.r-universe.dev/builds)
 
@@ -21,13 +21,13 @@ The additional repository can be made available permanently by adding the line a
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r 
+```r
 install.packages("mip")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r 
+```r
 update.packages()
 ```
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact David Klein <dklein@pik-potsdam.d
 
 To cite package **mip** in publications use:
 
-Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T, Salzwedel R, Lécuyer F (2026). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.155.12, <https://github.com/pik-piam/mip>.
+Klein D, Dietrich J, Baumstark L, Humpenoeder F, Stevanovic M, Wirth S, Führlich P, Richters O, Rüter T, Salzwedel R, Lécuyer F (2026). "mip: Comparison of multi-model runs." doi:10.5281/zenodo.1158586 <https://doi.org/10.5281/zenodo.1158586>, Version: 0.156.0, <https://github.com/pik-piam/mip>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
   title = {mip: Comparison of multi-model runs},
   author = {David Klein and Jan Philipp Dietrich and Lavinia Baumstark and Florian Humpenoeder and Miodrag Stevanovic and Stephen Wirth and Pascal Führlich and Oliver Richters and Tonn Rüter and Robert Salzwedel and Fabrice Lécuyer},
   doi = {10.5281/zenodo.1158586},
-  date = {2026-05-15},
+  date = {2026-06-18},
   year = {2026},
   url = {https://github.com/pik-piam/mip},
-  note = {Version: 0.155.12},
+  note = {Version: 0.156.0},
 }
 ```

--- a/man/plotstyle.Rd
+++ b/man/plotstyle.Rd
@@ -37,7 +37,7 @@ plotstyle brewed colors}
 \item{regexp}{If \code{TRUE}, match entities as regular expressions. Matching
 entities are expanded, non-matching entities are returned as the original
 expression.  Does not generate default color maps. Implies \code{plot =
-  FALSE} and \code{verbosity = 0}.}
+FALSE} and \code{verbosity = 0}.}
 
 \item{strip_units}{If \code{TRUE} everything from the first opening
 brace (\code{'('}) on is stripped from the entity names.  Defaults to \code{TRUE} and

--- a/man/showAreaAndBarPlots.Rd
+++ b/man/showAreaAndBarPlots.Rd
@@ -8,7 +8,7 @@ showAreaAndBarPlots(...)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createAreaAndBarPlots]{createAreaAndBarPlots}}
+  Arguments passed on to \code{\link{createAreaAndBarPlots}}
   \describe{
     \item{\code{data}}{A quitte object or an object that can be transformed into a
 quitte object.}

--- a/man/showAreaAndBarPlotsPlus.Rd
+++ b/man/showAreaAndBarPlotsPlus.Rd
@@ -8,7 +8,7 @@ showAreaAndBarPlotsPlus(...)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createAreaAndBarPlotsPlus]{createAreaAndBarPlotsPlus}}
+  Arguments passed on to \code{\link{createAreaAndBarPlotsPlus}}
   \describe{
     \item{\code{tot}}{A single string. A total value to be shown in the area plots.}
     \item{\code{plusNum}}{A single number. Number of "+"symbols for disaggregation.}

--- a/man/showLinePlots.Rd
+++ b/man/showLinePlots.Rd
@@ -8,7 +8,7 @@ showLinePlots(...)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createLinePlots]{createLinePlots}}
+  Arguments passed on to \code{\link{createLinePlots}}
   \describe{
     \item{\code{vars}}{A character vector of variables to be plotted. Defaults to all
 variables in `data`.}

--- a/man/showLinePlotsWithTarget.Rd
+++ b/man/showLinePlotsWithTarget.Rd
@@ -8,7 +8,7 @@ showLinePlotsWithTarget(...)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createLinePlotsWithTarget]{createLinePlotsWithTarget}}
+  Arguments passed on to \code{\link{createLinePlotsWithTarget}}
   \describe{
     \item{\code{vars}}{A character vector. Usually just a single string. The variables
 to be plotted.}

--- a/man/showLinePlotsWithZones.Rd
+++ b/man/showLinePlotsWithZones.Rd
@@ -13,7 +13,7 @@ showLinePlotsWithZones(
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createLinePlots]{createLinePlots}}
+  Arguments passed on to \code{\link{createLinePlots}}
   \describe{
     \item{\code{vars}}{A character vector of variables to be plotted. Defaults to all
 variables in `data`.}

--- a/man/showMultiLinePlots.Rd
+++ b/man/showMultiLinePlots.Rd
@@ -8,7 +8,7 @@ showMultiLinePlots(...)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createMultiLinePlots]{createMultiLinePlots}}
+  Arguments passed on to \code{\link{createMultiLinePlots}}
   \describe{
     \item{\code{vars}}{A character vector. The variables to be plotted.}
     \item{\code{nrowNum}}{An integer value. Number of rows of the panel figures}

--- a/man/showMultiLinePlotsByVariable.Rd
+++ b/man/showMultiLinePlotsByVariable.Rd
@@ -8,7 +8,7 @@ showMultiLinePlotsByVariable(...)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createMultiLinePlotsByVariable]{createMultiLinePlotsByVariable}}
+  Arguments passed on to \code{\link{createMultiLinePlotsByVariable}}
   \describe{
     \item{\code{xVar}}{A single string. The variable for the x-axis.}
     \item{\code{showHistorical}}{A single logical value. Should historical data be

--- a/man/showRegiLinePlots.Rd
+++ b/man/showRegiLinePlots.Rd
@@ -8,7 +8,7 @@ showRegiLinePlots(...)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=createRegiLinePlots]{createRegiLinePlots}}
+  Arguments passed on to \code{\link{createRegiLinePlots}}
   \describe{
     \item{\code{excludeMainRegion}}{A single logical value. Should the main region be
 excluded (or shown in the same plot)?}


### PR DESCRIPTION
This ensures that we install a version that does not break rendering of validation pdfs in case there is a section that only generates a warning but no other output (fixed in https://github.com/yihui/knitr/pull/2431).